### PR TITLE
Make example conform to draft version -01

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@ This repository contains a server and client implementation of the [draft-ietf-h
 The implementations are based on the draft -00 with following additional proposals:
 
 - Server-generated upload URLs (https://github.com/httpwg/http-extensions/pull/2292)
-- Retry-able upload creations using Idempotency-Key (https://github.com/httpwg/http-extensions/issues/2293)
 
 ## Requirements
 
@@ -80,26 +79,5 @@ HTTP/1.1 200 OK
 Upload-Incomplete: ?0
 Upload-Offset: 11
 Date: Fri, 11 Nov 2022 01:12:31 GMT
-Content-Length: 0
-```
-
-3. Upload a file while retrying the Upload Creation Procedure using Idempotency-Key:
-```
-$ curl -i -X POST -H 'Upload-Incomplete: ?0' -H 'Idempotency-Key: foo' -d 'hello world' http://localhost:8080/
-HTTP/1.1 104 status code 104
-Location: http://localhost:8080/uploads/5d167756-db41-4a5a-855f-5af346c23558
-
-HTTP/1.1 201 Created
-Location: http://localhost:8080/uploads/5d167756-db41-4a5a-855f-5af346c23558
-Upload-Incomplete: ?0
-Upload-Offset: 11
-Date: Fri, 11 Nov 2022 01:15:22 GMT
-Content-Length: 0
-
-$ curl -i -X POST -H 'Upload-Incomplete: ?0' -H 'Idempotency-Key: foo' -d 'hello world' http://localhost:8080/
-HTTP/1.1 200 OK
-Upload-Incomplete: ?0
-Upload-Offset: 11
-Date: Fri, 11 Nov 2022 01:15:25 GMT
 Content-Length: 0
 ```

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repository contains a server and client implementation of the [draft-ietf-httpbis-resumable-upload](https://datatracker.ietf.org/doc/draft-ietf-httpbis-resumable-upload/). Its latest iteration can be found at the [httpwg/http-extensions repository](https://github.com/httpwg/http-extensions/blob/main/draft-ietf-httpbis-resumable-upload.md).
 
-The implementations are based on the draft -00 with following additional proposals:
+The implementations are based on the draft [-01](https://datatracker.ietf.org/doc/draft-ietf-httpbis-resumable-upload/01/).
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@ This repository contains a server and client implementation of the [draft-ietf-h
 
 The implementations are based on the draft -00 with following additional proposals:
 
-- Server-generated upload URLs (https://github.com/httpwg/http-extensions/pull/2292)
-
 ## Requirements
 
 The implementations have been developed using Go 1.19.

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 This repository contains a server and client implementation of the [draft-ietf-httpbis-resumable-upload](https://datatracker.ietf.org/doc/draft-ietf-httpbis-resumable-upload/). Its latest iteration can be found at the [httpwg/http-extensions repository](https://github.com/httpwg/http-extensions/blob/main/draft-ietf-httpbis-resumable-upload.md).
 
 The implementations are based on the draft -00 with following additional proposals:
+
 - Server-generated upload URLs (https://github.com/httpwg/http-extensions/pull/2292)
 - Retry-able upload creations using Idempotency-Key (https://github.com/httpwg/http-extensions/issues/2293)
 
@@ -17,7 +18,7 @@ The client is located at `client/`. Currently, it is not able to upload files bu
 To run it (after running the server in a separate terminal):
 
 ```
-go run client/main.go
+cd client/ && go run main.go
 ```
 
 ## Server
@@ -27,7 +28,7 @@ The server is located at `server/`. Once started, it accepts the Upload Creation
 To run it:
 
 ```
-go run server/main.go
+cd server/ && go run main.go
 ```
 
 ## Curl Examples
@@ -48,6 +49,7 @@ Content-Length: 0
 ```
 
 2. Upload a file over two requests using Upload Appending Procedure and an Offset Retrieving Procedure:
+
 ```
 $ curl -i -X POST -H 'Upload-Incomplete: ?1' http://localhost:8080/
 HTTP/1.1 104 status code 104

--- a/server/main.go
+++ b/server/main.go
@@ -1,11 +1,8 @@
 package main
 
 import (
-	"crypto/sha256"
-	"encoding/hex"
 	"errors"
 	"io"
-	"io/fs"
 	"log"
 	"net/http"
 	"os"
@@ -35,70 +32,21 @@ func UploadCreationHandler(w http.ResponseWriter, r *http.Request) {
 	var file *os.File
 	var err error
 
-	idempotencyKey := getIdempotencyKey(r)
-	if idempotencyKey != "" {
-		content, err := os.ReadFile("./uploads/" + idempotencyKey)
-		if err != nil {
-			if !errors.Is(err, fs.ErrNotExist) {
-				sendError(w, err)
-				return
-			}
-		} else {
-			uploadId = string(content)
+	// Create a new upload.
+	uploadId = uuid.NewString()
 
-			var isComplete bool
-			var exists bool
-			var offset int64
-			file, exists, isComplete, offset, err = loadUpload(uploadId)
-			if err != nil {
-				sendError(w, err)
-				return
-			}
-			if !exists {
-				uploadId = ""
-			} else {
-				defer file.Close()
-				if isComplete {
-					// If the upload is complete, we simply discard the request body
-					// and respond with the upload state.
-					setUploadHeaders(w, isComplete, offset)
-					return
-				}
-
-				// Discard bytes, so request body is at same offset as file
-				if _, err := io.CopyN(io.Discard, r.Body, offset); err != nil {
-					sendError(w, err)
-					return
-				}
-			}
-		}
+	// Create file to save uploaded chunks
+	file, err = os.OpenFile("./uploads/"+uploadId, os.O_WRONLY|os.O_CREATE, 0o644)
+	if err != nil {
+		sendError(w, err)
+		return
 	}
+	defer file.Close()
 
-	// If we were not able to find an upload using an idempotency key, create a new upload.
-	if uploadId == "" {
-		uploadId = uuid.NewString()
-
-		// Create file to save uploaded chunks
-		file, err = os.OpenFile("./uploads/"+uploadId, os.O_WRONLY|os.O_CREATE, 0o644)
-		if err != nil {
-			sendError(w, err)
-			return
-		}
-		defer file.Close()
-
-		// Create file to indicate incompleteness
-		if err := os.WriteFile("./uploads/"+uploadId+".incomplete", nil, 0o644); err != nil {
-			sendError(w, err)
-			return
-		}
-
-		if idempotencyKey != "" {
-			// Create file to look up idempotency key
-			if err := os.WriteFile("./uploads/"+idempotencyKey, []byte(uploadId), 0o644); err != nil {
-				sendError(w, err)
-				return
-			}
-		}
+	// Create file to indicate incompleteness
+	if err := os.WriteFile("./uploads/"+uploadId+".incomplete", nil, 0o644); err != nil {
+		sendError(w, err)
+		return
 	}
 
 	// Respond with informational response
@@ -229,18 +177,6 @@ func UploadCancellationHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	_ = os.Remove(UploadDir + id + ".incomplete")
-
-	// TODO: link from Idempotency-Key should also be removed, if available
-}
-
-func getIdempotencyKey(r *http.Request) string {
-	idempotencyKey := r.Header.Get("Idempotency-Key")
-	if idempotencyKey == "" {
-		return ""
-	}
-
-	sum := sha256.Sum256([]byte(idempotencyKey))
-	return hex.EncodeToString(sum[:])
 }
 
 func getUploadIncomplete(r *http.Request) bool {

--- a/server/main.go
+++ b/server/main.go
@@ -13,6 +13,7 @@ import (
 )
 
 const UploadDir = "./uploads/"
+const InteropVersion = "3"
 
 func main() {
 	r := mux.NewRouter()
@@ -49,10 +50,15 @@ func UploadCreationHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Respond with informational response
 	uploadUrl := "http://localhost:8080/uploads/" + uploadId
 	w.Header().Set("Location", uploadUrl)
-	w.WriteHeader(104)
+
+	// Respond with informational response, if interop version matches
+	if getInteropVersion(r) == InteropVersion {
+		w.Header().Set("Upload-Draft-Interop-Version", InteropVersion)
+		w.WriteHeader(104)
+		w.Header().Del("Upload-Draft-Interop-Version")
+	}
 
 	// Copy request body to file
 	_, err = io.Copy(file, r.Body)
@@ -177,6 +183,10 @@ func UploadCancellationHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	_ = os.Remove(UploadDir + id + ".incomplete")
+}
+
+func getInteropVersion(r *http.Request) string {
+	return r.Header.Get("Upload-Draft-Interop-Version")
 }
 
 func getUploadIncomplete(r *http.Request) bool {


### PR DESCRIPTION
The example has been developed for -00 with some additional proposals. This PR updates the example to target -01 from https://datatracker.ietf.org/doc/draft-ietf-httpbis-resumable-upload/01/ without additional proposals.