### PR TITLE
Add support for receiving Upload-Offset in 104 response

### DIFF
--- a/clients/go/main.go
+++ b/clients/go/main.go
@@ -108,17 +108,17 @@ func uploadCreationProcedure(file *os.File) (string, error) {
 			}
 
 			uploadOffset := header.Get("Upload-Offset")
-
 			if uploadOffset != "" {
-				log.Printf("Received 104 response. Server reported to have saved %s bytes\n", uploadOffset)
-				return nil
+				log.Printf("Received 104 response. Server reported to have saved %s bytes\n", uploadOffset
 			}
 
 			uploadUrl := header.Get("Location")
-			log.Printf("Received 104 response. Location is: %s\n", uploadUrl)
-
-			if err := saveUploadState(uploadUrl); err != nil {
-				log.Printf("failed to write upload state file: %s", err)
+			if uploadUrl != "" {
+				log.Printf("Received 104 response. Location is: %s\n", uploadUrl)
+	
+				if err := saveUploadState(uploadUrl); err != nil {
+					log.Printf("failed to write upload state file: %s", err)
+				}
 			}
 
 			return nil

--- a/clients/go/main.go
+++ b/clients/go/main.go
@@ -107,6 +107,13 @@ func uploadCreationProcedure(file *os.File) (string, error) {
 				return nil
 			}
 
+			uploadOffset := header.Get("Upload-Offset")
+
+			if uploadOffset != "" {
+				log.Printf("Received 104 response. Server reported to have saved %s bytes\n", uploadOffset)
+				return nil
+			}
+
 			uploadUrl := header.Get("Location")
 			log.Printf("Received 104 response. Location is: %s\n", uploadUrl)
 


### PR DESCRIPTION
As the title says. Please be gentle, it's soon Christmas and I'm a total n00b with regards to Go :D 

Running this on Windows, using `go version go1.21.5 windows/amd64`, returns the following. I don't think this is an issue in the client but rather something with the runtime (or possibly Windows?). It works when using cURL 8.1.1.

```
> go run main.go --file c:\testfile.bin --endpoint https://localhost:5007/files-tus-2/ --state ./upload-state.txt

2023/12/22 14:11:23 Received 104 response. Location is: https://localhost:5007/files-tus-2/d5748fe91b85404eb37b041266d1d835
2023/12/22 14:11:23 Received 104 response. Server reported to have saved 4096 bytes
2023/12/22 14:11:23 Received 104 response. Server reported to have saved 8192 bytes
2023/12/22 14:11:23 Received 104 response. Server reported to have saved 12288 bytes
2023/12/22 14:11:23 Received 104 response. Server reported to have saved 16384 bytes
2023/12/22 14:11:23 upload creation procedure failed: Post "https://localhost:5007/files-tus-2/": stream error: stream ID 1; PROTOCOL_ERROR; http2: too many 1xx informational responses
exit status 1
```